### PR TITLE
Deny clippy::string_slice to prevent UTF-8 panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 
 [[package]]
 name = "ogn-parser"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "approx",
  "chrono",
@@ -382,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "ogn-parser-pyo3"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "ogn-parser",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 [workspace.package]
 version = "0.3.16"
 license = "MIT/Apache-2.0"
+
+[workspace.lints.clippy]
+string_slice = "deny"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,6 +19,9 @@ regex = "1.11.1"
 flat_projection = "0.4.0"
 rust_decimal = "1.37.1"
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 approx = "0.5.1"
 csv = "1.3.0"

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -22,7 +22,11 @@ pub fn split_value_unit(s: &str) -> Option<(&str, &str)> {
         .last()
         .and_then(|(split_position, has_digits)| {
             if has_digits && split_position != length - 1 {
-                Some((&s[..(split_position + 1)], &s[(split_position + 1)..]))
+                // Use get() to safely split without panicking on UTF-8 boundaries
+                match (s.get(..(split_position + 1)), s.get((split_position + 1)..)) {
+                    (Some(value), Some(unit)) => Some((value, unit)),
+                    _ => None,
+                }
             } else {
                 None
             }

--- a/pyo3/Cargo.toml
+++ b/pyo3/Cargo.toml
@@ -11,6 +11,9 @@ license.workspace = true
 name = "ogn_parser"
 crate-type = ["cdylib"]
 
+[lints]
+workspace = true
+
 [dependencies]
 pyo3 = { version= "0.25.0", features = ["chrono", "rust_decimal"] }
 rayon = "1.10.0"


### PR DESCRIPTION
## Summary
- Adds `clippy::string_slice = "deny"` at the workspace level to catch any `&str[range]` indexing at compile time
- Fixes the one remaining violation in `utils.rs` by using safe `str::get()` instead of direct indexing
- Both `core` and `pyo3` crates inherit the workspace lint

This would have caught the UTF-8 slicing panic fixed in #8 before it ever shipped.

## Test plan
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 115 tests pass